### PR TITLE
Add WORKER_TIMEOUT param

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ curl "http://localhost:7878/search?q=1+rue+de+la+paix+paris"
 | Nom du paramètre | Description |
 | ----- | ----- |
 | `WORKERS` | Nombre de workers addok à lancer. Valeur par défaut : `1`. |
+| `WORKER_TIMEOUT` | [Durée maximale allouée à un worker](http://docs.gunicorn.org/en/0.17.2/configure.html#timeout) pour effectuer une opération de géocodage. Valeur par défaut : `30`. |

--- a/addok/docker-entrypoint.sh
+++ b/addok/docker-entrypoint.sh
@@ -28,5 +28,5 @@ fi
 cat /etc/addok/addok.patched.conf
 
 WORKERS=${WORKERS:-1}
-
-gunicorn -w $WORKERS -b 0.0.0.0:7878 --access-logfile - addok.http.wsgi
+WORKER_TIMEOUT=${WORKER_TIMEOUT:-30}
+gunicorn -w $WORKERS --timeout $WORKER_TIMEOUT -b 0.0.0.0:7878 --access-logfile - addok.http.wsgi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     - addok-redis:redis
     environment:
       WORKERS: 1
+      WORKER_TIMEOUT: 30
       LOG_QUERIES: 1
       LOG_NOT_FOUND: 1
       SLOW_QUERIES: 200


### PR DESCRIPTION
Dans un scénario d'utilisation impliquant un géo-codage de masse, je me suis aperçu que les workers gunicorn étaient tués régulièrement avant de pouvoir renvoyer un résultat (même pour des fichiers de seulement 1500 lignes).

En creusant un peu, j'ai trouvé le paramètre [timeout](http://docs.gunicorn.org/en/0.17.2/configure.html#timeout) qui permet de gérer la durée maximale allouée à un worker avant de fermer brutalement la connexion. Je propose donc de permettre à l'utilisateur de choisir lui-même ce paramètre via la variable d'environnement `WORKER_TIMEOUT`.

Dans mon cas, sur une machine peu puissante, passer ce paramètre à 120 secondes rend l'opération réalisable.